### PR TITLE
Add recovery options for lost passcodes

### DIFF
--- a/src/preload.cjs
+++ b/src/preload.cjs
@@ -25,4 +25,7 @@ contextBridge.exposeInMainWorld('api', {
   /* Backup */
   exportBackup: () => ipcRenderer.invoke('backup:export'),
   importBackup: () => ipcRenderer.invoke('backup:import'),
+
+  /* Environment */
+  resetEnvironment: () => ipcRenderer.invoke('env:reset'),
 });

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -88,7 +88,10 @@ async function unlockFlow() {
     `,
     okText: 'Unlock',
   });
-  if (!pass) return; // user cancelled — they'll see empty UI; can refresh to retry
+  if (!pass) {
+    await handleForgotPasscode();
+    return;
+  }
 
   try {
     const res = await api.securityUnlock(pass);
@@ -98,8 +101,8 @@ async function unlockFlow() {
     }
   } catch (e) {
     console.error('Passcode unlock failed:', e);
-    alert('Unlock failed. Try again.');
-    return unlockFlow();
+    alert('Unlock failed.');
+    await handleForgotPasscode();
   }
 }
 
@@ -126,6 +129,37 @@ async function maybeEnableEncryptionFlow() {
   }
   await api.securityEnable(p, useBio);
   state.unlocked = true;
+}
+
+async function handleForgotPasscode() {
+  const choice = await promptModalWithReturn({
+    title: 'Forgot Passcode?',
+    bodyHTML: `
+      <p>You can create a new empty environment or restore from a backup file.</p>
+    `,
+    okText: 'Create New',
+    cancelText: 'Restore Backup',
+  });
+
+  if (choice.canceled) {
+    // Restore from backup
+    const res = await api.importBackup();
+    if (res?.ok) {
+      location.reload();
+      return;
+    }
+  } else {
+    // Create new environment
+    const sure = confirm('This will erase your existing data. Continue?');
+    if (sure) {
+      await api.resetEnvironment();
+      location.reload();
+      return;
+    }
+  }
+
+  // If we get here, user canceled restore/reset. Retry unlock flow.
+  return unlockFlow();
 }
 
 /* ---------- Modal helpers ---------- */


### PR DESCRIPTION
## Summary
- Allow users to reset the application data when the passcode is lost
- Expose environment reset API and wire renderer flow to offer reset or backup restore

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689f851a3064832fb247a266d349ba39