### PR TITLE
Add task search bar

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -53,6 +53,7 @@
         <header class="main-header">
           <h2 id="view-title">Today</h2>
           <div class="spacer"></div>
+          <input id="search" class="search-input" type="search" placeholder="Search tasks..." />
         </header>
 
         <section class="task-input">

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -8,6 +8,7 @@ const state = {
   db: null,
   view: { type: 'today', projectId: null },
   showCompleted: false,
+  searchQuery: '',
   security: { encryptionEnabled: false, useBiometrics: false, biometricsAvailable: false },
   unlocked: false,
 };
@@ -285,13 +286,20 @@ function bindNav() {
 }
 
 function bindInputs() {
+  // Handle search input
+  const search = el('#search');
+  search?.addEventListener('input', (e) => {
+    state.searchQuery = e.target.value.toLowerCase();
+    renderTasks();
+  });
+
   // Handle Enter key submission for new task
   el('#new-title').addEventListener('keypress', (e) => {
     if (e.key === 'Enter') {
       onAddTask();
     }
   });
-  
+
   // Handle option button clicks
   bindOptionButtons();
 }
@@ -519,12 +527,25 @@ function renderTasks() {
   const container = el('#task-container');
   container.innerHTML = '';
 
+  if (state.searchQuery) {
+    const q = state.searchQuery.toLowerCase();
+    const tasks = (state.db?.tasks || []).filter((t) =>
+      t.title.toLowerCase().includes(q)
+    );
+    if (!tasks.length) {
+      container.innerHTML = `<div style="padding:16px;color:#8a94a6;">No matching tasks.</div>`;
+      return;
+    }
+    sortTasks(tasks).forEach((t) => container.appendChild(renderTaskItem(t)));
+    return;
+  }
+
   if (state.view.type === 'week') {
     return renderWeekList(container);
   }
 
   const tasks = getFilteredTasks();
-  
+
   if (!tasks.length) {
     container.innerHTML = `<div style="padding:16px;color:#8a94a6;">No tasks yet.</div>`;
     return;

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -288,6 +288,18 @@ summary,
   font-weight: 600;
 }
 
+.main-header .search-input {
+  padding: 6px 8px;
+  border-radius: 6px;
+  border: 1px solid var(--line);
+  background: var(--panel);
+  color: var(--text);
+}
+
+.main-header .search-input::placeholder {
+  color: var(--muted);
+}
+
 .spacer {
   flex: 1;
 }


### PR DESCRIPTION
## Summary
- add search input in main header to filter tasks by title
- support searching all tasks regardless of completion or view
- style the search bar for seamless appearance

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689f8557d634832fbe564bb7e27b0bf6