### PR TITLE
Inline add task input below task list

### DIFF
--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -16,6 +16,8 @@ const state = {
 const el = (sel) => document.querySelector(sel);
 const els = (sel) => Array.from(document.querySelectorAll(sel));
 
+let taskInputSection;
+
 /* ---- Titlebar window controls ---- */
 document.addEventListener('DOMContentLoaded', init);
 
@@ -28,6 +30,8 @@ async function init() {
     // Offer to enable encryption on first run
     await maybeEnableEncryptionFlow();
   }
+
+  taskInputSection = el('.task-input');
 
   await loadAndRender();
   bindNav();
@@ -522,6 +526,11 @@ function renderTasks() {
   const container = el('#task-container');
   container.innerHTML = '';
 
+  if (state.view.type === 'week') {
+    renderWeekList(container);
+    return;
+  }
+
   if (state.searchQuery) {
     const q = state.searchQuery.toLowerCase();
     const tasks = (state.db?.tasks || []).filter((t) =>
@@ -529,23 +538,18 @@ function renderTasks() {
     );
     if (!tasks.length) {
       container.innerHTML = `<div style="padding:16px;color:#8a94a6;">No matching tasks.</div>`;
-      return;
+    } else {
+      sortTasks(tasks).forEach((t) => container.appendChild(renderTaskItem(t)));
     }
-    sortTasks(tasks).forEach((t) => container.appendChild(renderTaskItem(t)));
+    container.appendChild(taskInputSection);
     return;
-  }
-
-  if (state.view.type === 'week') {
-    return renderWeekList(container);
   }
 
   const tasks = getFilteredTasks();
-
-  if (!tasks.length) {
-    container.innerHTML = `<div style="padding:16px;color:#8a94a6;">No tasks yet.</div>`;
-    return;
+  if (tasks.length) {
+    tasks.forEach((t) => container.appendChild(renderTaskItem(t)));
   }
-  tasks.forEach((t) => container.appendChild(renderTaskItem(t)));
+  container.appendChild(taskInputSection);
 }
 
 /* ---------- NEW: Vertical Week view ---------- */

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -329,7 +329,7 @@ summary,
   background: #1a2028;
   border: 1px solid #2b3441;
   color: var(--text);
-  border-radius: 8px;
+  border-radius: 0;
   padding: 10px;
 }
 .task-input button {
@@ -338,7 +338,7 @@ summary,
 
 /* ===== Task List Container ===== */
 .task-container {
-  padding: 10px 12px 40px;
+  padding: 10px 12px;
   overflow: auto;
   flex: 1;
 }
@@ -915,7 +915,7 @@ button:active {
   background: var(--accent);
   border: 1px solid var(--accent);
   color: white;
-  border-radius: 6px;
+  border-radius: 0;
   padding: 8px 12px;
   cursor: pointer;
   font-weight: 600;


### PR DESCRIPTION
## Summary
- Position the add-task form directly in the task list and reuse it after list renders
- Remove border radii and extra padding so the input sits flush with tasks

## Testing
- `npm test` *(fails: Missing script "test" )*

------
https://chatgpt.com/codex/tasks/task_e_689fb22c7c5c832f8f1d11e25645d92a