### PR TITLE
Hide due date chip in weekly day sections

### DIFF
--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -690,7 +690,9 @@ function renderTaskItem(t) {
     const p = (state.db?.projects || []).find((x) => x.id === t.projectId);
     if (p) meta.appendChild(chip(p.name));
   }
-  if (t.dueDate) meta.appendChild(chip(`Due ${formatYMD(t.dueDate)}`));
+  // Hide due date chip when tasks are displayed within week view day sections
+  if (t.dueDate && state.view.type !== 'week')
+    meta.appendChild(chip(`Due ${formatYMD(t.dueDate)}`));
   if (t.priority > 0) {
     const priorityChip = chip(`P${t.priority}`);
     priorityChip.className += ` priority-${t.priority}`;


### PR DESCRIPTION
## Summary
- Hide due date chips for tasks shown inside weekly view day sections

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68a00107ad68832f9cd6d5e80682170c