### PR TITLE
Hide default project label on task items

### DIFF
--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -686,7 +686,7 @@ function renderTaskItem(t) {
     meta.appendChild(priorityIndicator);
   }
   
-  if (t.projectId) {
+  if (t.projectId && t.projectId !== 'inbox') {
     const p = (state.db?.projects || []).find((x) => x.id === t.projectId);
     if (p) meta.appendChild(chip(p.name));
   }


### PR DESCRIPTION
## Summary
- avoid displaying the default "Inbox" project label on task items

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a000f78990832f852389cf91bc6b5c